### PR TITLE
Expose rawActions via signProvider

### DIFF
--- a/lib/apiCaller.js
+++ b/lib/apiCaller.js
@@ -2425,6 +2425,7 @@ var APICaller = function () {
         value: function () {
             var _ref30 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee30() {
                 var actions,
+                    rawActions,
                     hasConfig,
                     trxConf,
                     privateKeys,
@@ -2450,6 +2451,7 @@ var APICaller = function () {
                         switch (_context30.prev = _context30.next) {
                             case 0:
                                 actions = [];
+                                rawActions = [];
                                 hasConfig = false;
 
                                 // default config
@@ -2472,33 +2474,33 @@ var APICaller = function () {
                                 privateKeys = [];
                                 publicKeys = [];
 
-                                // user can use availablePublicKeys in config for estimate, or use keyProvider as a backup
+                                // user can use availablePublicKeys in config for estimate, or use keyProvider instead
 
                                 if (!(!trxConf.__estimateCharge || !trxConf.availablePublicKeys)) {
-                                    _context30.next = 13;
+                                    _context30.next = 14;
                                     break;
                                 }
 
-                                _context30.next = 9;
+                                _context30.next = 10;
                                 return this.__calcKeyProvider(this.config.keyProvider, null);
 
-                            case 9:
+                            case 10:
                                 privateKeys = _context30.sent;
 
                                 publicKeys = privateKeys.map(function (x) {
                                     return EvtKey.privateToPublic(x);
                                 });
-                                _context30.next = 16;
+                                _context30.next = 17;
                                 break;
 
-                            case 13:
-                                _context30.next = 15;
+                            case 14:
+                                _context30.next = 16;
                                 return this.__calcPublicKeyProvider(trxConf.availablePublicKeys);
 
-                            case 15:
+                            case 16:
                                 publicKeys = _context30.sent;
 
-                            case 16:
+                            case 17:
 
                                 // set default payer if user provided only one private key
                                 if (!trxConf.payer && privateKeys.length == 1) {
@@ -2509,32 +2511,34 @@ var APICaller = function () {
                                     actions.push(_args30[i]);
                                 }
 
+                                rawActions = actions.slice();
+
                                 // check arguments
 
                                 if (!(actions.length == 0)) {
-                                    _context30.next = 20;
+                                    _context30.next = 22;
                                     break;
                                 }
 
                                 throw new Error("At least 1 action needed");
 
-                            case 20:
+                            case 22:
                                 if (!(trxConf.maxCharge == null || !(0, _isInteger2.default)(trxConf.maxCharge))) {
-                                    _context30.next = 22;
+                                    _context30.next = 24;
                                     break;
                                 }
 
                                 throw new Error("maxCharge is required and must be a integer greater than or eqaul to 0");
 
-                            case 22:
+                            case 24:
                                 if (!(!trxConf.__estimateCharge && (trxConf.payer == null || !EvtKey.isValidAddress(trxConf.payer)))) {
-                                    _context30.next = 24;
+                                    _context30.next = 26;
                                     break;
                                 }
 
                                 throw new Error("payer is required and must be a valid address as a string");
 
-                            case 24:
+                            case 26:
                                 params = {
                                     transaction: {
                                         actions: actions
@@ -2543,13 +2547,13 @@ var APICaller = function () {
                                 // check arguments
 
                                 if (params.transaction) {
-                                    _context30.next = 27;
+                                    _context30.next = 29;
                                     break;
                                 }
 
                                 throw new Error("invalid format of params: no transaction field");
 
-                            case 27:
+                            case 29:
 
                                 params.sign = params.sign !== false ? true : false;
 
@@ -2562,15 +2566,15 @@ var APICaller = function () {
                                 // It can not be changed to do in cycle because node split some information into sections
                                 // and you can't guess when it will be expired
 
-                                _context30.next = 31;
+                                _context30.next = 33;
                                 return this.getInfo();
 
-                            case 31:
+                            case 33:
                                 _i = 0;
 
-                            case 32:
+                            case 34:
                                 if (!(_i < body.transaction.actions.length)) {
-                                    _context30.next = 56;
+                                    _context30.next = 58;
                                     break;
                                 }
 
@@ -2578,10 +2582,10 @@ var APICaller = function () {
                                     body.transaction.actions[_i] = new EvtAction(body.transaction.actions[_i].action, body.transaction.actions[_i].args);
                                 }
 
-                                _context30.next = 36;
+                                _context30.next = 38;
                                 return body.transaction.actions[_i].calculateDomainAndKey();
 
-                            case 36:
+                            case 38:
 
                                 /** @type {EvtAction} */
                                 originalAction = body.transaction.actions[_i];
@@ -2589,10 +2593,10 @@ var APICaller = function () {
                                 // create binary action for push_transaction
 
                                 _context30.t0 = originalAction.actionName;
-                                _context30.next = 40;
+                                _context30.next = 42;
                                 return this.__chainAbiJsonToBin({ action: originalAction.actionName, args: originalAction.abi }, trxConf.AbiJsonToBinLocally);
 
-                            case 40:
+                            case 42:
                                 _context30.t1 = _context30.sent.binargs;
                                 _context30.t2 = originalAction.domain;
                                 _context30.t3 = originalAction.key;
@@ -2604,15 +2608,15 @@ var APICaller = function () {
                                 };
 
                                 if (!(binAction.name == "everipay")) {
-                                    _context30.next = 52;
+                                    _context30.next = 54;
                                     break;
                                 }
 
                                 trxConf.__hasEveriPay = true;
-                                _context30.next = 48;
+                                _context30.next = 50;
                                 return EvtLink.parseEvtLink(originalAction.abi.link);
 
-                            case 48:
+                            case 50:
                                 _context30.t4 = function (x) {
                                     return x.typeKey == 156;
                                 };
@@ -2620,64 +2624,64 @@ var APICaller = function () {
                                 trxConf.__linkId = _context30.sent.segments.filter(_context30.t4)[0].value.toString("hex");
 
                                 if (!trxConf.expiration) {
-                                    _context30.next = 52;
+                                    _context30.next = 54;
                                     break;
                                 }
 
                                 throw new Error("Expiration can not be set in a transaction including a everipay action, the expiration must be set automatically by evtjs");
 
-                            case 52:
+                            case 54:
 
                                 // override action
                                 body.transaction.actions[_i] = binAction;
 
-                            case 53:
+                            case 55:
                                 ++_i;
-                                _context30.next = 32;
+                                _context30.next = 34;
                                 break;
 
-                            case 56:
+                            case 58:
                                 expiration = void 0, hash = void 0, numHex = void 0, last_irreversible_block_num = void 0, last_irreversible_block_prefix = void 0;
 
                                 // process referenced block number and expiration time for transaction
 
                                 if (!trxConf.expiration) {
-                                    _context30.next = 61;
+                                    _context30.next = 63;
                                     break;
                                 }
 
                                 expiration = trxConf.expiration;
-                                _context30.next = 76;
+                                _context30.next = 78;
                                 break;
 
-                            case 61:
+                            case 63:
                                 if (!trxConf.__hasEveriPay) {
-                                    _context30.next = 70;
+                                    _context30.next = 72;
                                     break;
                                 }
 
                                 _context30.t5 = Date;
-                                _context30.next = 65;
+                                _context30.next = 67;
                                 return this.getNodeTimestamp();
 
-                            case 65:
+                            case 67:
                                 _context30.t6 = _context30.sent;
                                 _context30.t7 = _context30.t6 + 10000;
                                 expiration = new _context30.t5(_context30.t7).toISOString().substr(0, 19);
-                                _context30.next = 76;
+                                _context30.next = 78;
                                 break;
 
-                            case 70:
+                            case 72:
                                 _context30.t8 = Date;
-                                _context30.next = 73;
+                                _context30.next = 75;
                                 return this.getNodeTimestamp();
 
-                            case 73:
+                            case 75:
                                 _context30.t9 = _context30.sent;
                                 _context30.t10 = _context30.t9 + 100000;
                                 expiration = new _context30.t8(_context30.t10).toISOString().substr(0, 19);
 
-                            case 76:
+                            case 78:
 
                                 hash = ByteBuffer.fromHex(this.__cachedInfo.last_irreversible_block_id, true); // little endian
                                 numHex = this.__cachedInfo.last_irreversible_block_id.substr(4, 4);
@@ -2699,31 +2703,31 @@ var APICaller = function () {
                                 body.transaction.payer = trxConf.payer;
 
                                 if (!trxConf.__estimateCharge) {
-                                    _context30.next = 86;
+                                    _context30.next = 88;
                                     break;
                                 }
 
                                 return _context30.abrupt("return", { body: body, publicKeys: publicKeys });
 
-                            case 86:
+                            case 88:
                                 if (!params.sign) {
-                                    _context30.next = 96;
+                                    _context30.next = 98;
                                     break;
                                 }
 
-                                _context30.next = 89;
+                                _context30.next = 91;
                                 return this.__getDigestToSign(body.transaction);
 
-                            case 89:
+                            case 91:
                                 digestRes = _context30.sent.digest;
 
 
                                 // sign
                                 signBuf = new Buffer(digestRes, "hex");
-                                _context30.next = 93;
-                                return this.__signTransaction(signBuf, body.transaction, privateKeys);
+                                _context30.next = 95;
+                                return this.__signTransaction(signBuf, body.transaction, privateKeys, rawActions);
 
-                            case 93:
+                            case 95:
                                 sigs = _context30.sent;
 
 
@@ -2733,9 +2737,9 @@ var APICaller = function () {
 
                                 body.signatures = sigs;
 
-                            case 96:
+                            case 98:
                                 if (trxConf.submitToNode) {
-                                    _context30.next = 98;
+                                    _context30.next = 100;
                                     break;
                                 }
 
@@ -2744,14 +2748,14 @@ var APICaller = function () {
                                     config: trxConf
                                 });
 
-                            case 98:
-                                _context30.next = 100;
+                            case 100:
+                                _context30.next = 102;
                                 return this.pushSignedTransaction(body, trxConf.__hasEveriPay ? trxConf.__linkId : null);
 
-                            case 100:
+                            case 102:
                                 return _context30.abrupt("return", _context30.sent);
 
-                            case 101:
+                            case 103:
                             case "end":
                                 return _context30.stop();
                         }
@@ -2981,8 +2985,8 @@ var APICaller = function () {
 
     }, {
         key: "__signTransaction",
-        value: function __signTransaction(buf, transaction, privateKeys) {
-            return this.config.signProvider({ signHash: signHash, buf: buf, transaction: transaction, privateKeys: privateKeys });
+        value: function __signTransaction(buf, transaction, privateKeys, actions) {
+            return this.config.signProvider({ signHash: signHash, buf: buf, transaction: transaction, privateKeys: privateKeys, actions: actions });
         }
     }, {
         key: "__getDigestToSign",

--- a/src/apiCaller.js
+++ b/src/apiCaller.js
@@ -1010,6 +1010,7 @@ class APICaller {
      */
     async pushTransaction() {
         let actions = [ ];
+        let rawActions = [];
         let hasConfig = false;
 
         // default config
@@ -1047,6 +1048,8 @@ class APICaller {
         for (let i = (hasConfig ? 1 : 0); i < arguments.length; ++i) {
             actions.push(arguments[i]);
         }
+
+        rawActions = actions.slice()
 
         // check arguments
         if (actions.length == 0) {
@@ -1155,7 +1158,7 @@ class APICaller {
 
             // sign
             const signBuf = new Buffer(digestRes, "hex");
-            let sigs = await this.__signTransaction(signBuf, body.transaction, privateKeys);
+            let sigs = await this.__signTransaction(signBuf, body.transaction, privateKeys, rawActions);
 
             if (!Array.isArray(sigs)) {
                 sigs = [ sigs ];
@@ -1248,8 +1251,8 @@ class APICaller {
      * @param {object} transaction 
      * @param {string[]} privateKeys 
      */
-    __signTransaction(buf, transaction, privateKeys) {
-        return this.config.signProvider({signHash, buf, transaction, privateKeys});
+    __signTransaction(buf, transaction, privateKeys, actions) {
+        return this.config.signProvider({signHash, buf, transaction, privateKeys, actions});
     }
 
     async __getDigestToSign(transaction) { 


### PR DESCRIPTION
This PR is with the intension to expose rawActions via `signProvider` to better present the signing content. e.g. Instead of using 
```
{
  "name": "transferft",
  "data": "010002c8f0xxxxxxx",
  "domain": ".fungible",
  "key": "20"
}
```
to use 
```
{
  "actionName": "transferft",
  "abi": {
      "from": "EVT6Qz3wuRjyN6gaU3P3XRxpnEZnM4oPxortemaWDwFRvsv2FxgND",
      "to": "EVT6rn1vVAM8FfdT43Ast37yHqwRhoZkLpbxZXEtodJLYFFGA7Qzq",
      "number": "10.00000 S#20",
      "memo": "Test"
  },
  "domain": ".fungible",
  "key": "20"
}
```